### PR TITLE
allow wrapper cookbooks to use the provider

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer       'Tim Smith'
 maintainer_email 'tsmithi84@gmail.com'
 license          'Apache 2.0'
 description      'Installs and configures SmokePing server with fping'
-version          '1.1.0'
+version          '1.1.1'
 
 depends 'apache2'
 depends 'perl'

--- a/providers/target.rb
+++ b/providers/target.rb
@@ -23,6 +23,7 @@ action :create do
 
     file = "#{etc_dir}/config.d/#{name}.targets"
     template file do
+      cookbook 'smokeping'
       source 'group_targets.erb'
       mode '0644'
       variables(
@@ -37,6 +38,7 @@ action :create do
     file = "#{node['smokeping']['etc_dir']}/config.d/Targets"
 
     template file do
+      cookbook 'smokeping'
       source 'Targets.erb'
       owner 'root'
       group 'root'


### PR DESCRIPTION
When trying to use the 1.1.0 version of tas50/chef-smokeping I get:

==
       Recipe: sbo_smokeping::default
         * smokeping_target[Production] action create
           - Converging by Production



           Error executing action `create` on resource 'template[/etc/smokeping/config.d/Production.targets]'
       ================================================================================

           Chef::Exceptions::FileNotFound
       ------------------------------
           Cookbook 'sbo_smokeping' (0.1.0) does not contain a file at any of these locations:
             templates/ubuntu-14.04/group_targets.erb

         templates/default/group_targets.erb
             templates/group_targets.erb

           Resource Declaration:
       ---------------------
           # In /tmp/kitchen/cookbooks/smokeping/providers/target.rb

            25:     template file do
            26:       source 'group_targets.erb'
            27:       mode '0644'
            28:       variables(
        29:         :data => new_resource.data
            30:       )
            31:     end
        32:     Chef::Log.info "#{file} created"
==

This PR resolves that problem by specifying the template in the provider