### PR TITLE
Support of ubuntu 14.04

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -8,6 +8,7 @@ provisioner:
 
 platforms:
   - name: ubuntu-12.04
+  - name: ubuntu-14.04
 
 suites:
   - name: default

--- a/recipes/example_slave.rb
+++ b/recipes/example_slave.rb
@@ -16,6 +16,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-node.set['smokepling']['slave_mode'] = true
+node.set['smokeping']['slave_mode'] = true
 
 include_recipe 'smokeping::slave'


### PR DESCRIPTION
The patch adds support for using chef-smokeping on ubuntu 14.04.
Since apache2 configuration varies in ubuntu versions of 12.04 and 14.04, therefore changes are required to apache modifying recipe (_apache).

Please feel free to comment.